### PR TITLE
Use url hash fragments instead of search parameters to increase security

### DIFF
--- a/backend/src/routes/file_html.rs
+++ b/backend/src/routes/file_html.rs
@@ -6,8 +6,8 @@ use crate::{files::get_file, DbPool};
 
 #[derive(Deserialize)]
 struct SearchParams {
-    v: String,
-    k: String,
+    v: Option<String>,
+    k: Option<String>,
 }
 
 #[get("/file/{file_uuid}")]

--- a/frontend/file.js
+++ b/frontend/file.js
@@ -5,8 +5,8 @@ const errorP = document.querySelector('.error');
 
 const uuid = document.querySelector('input#uuid').value;
 const availableTill = document.querySelector('input#available_till').value;
-const iv = document.querySelector('input#iv').value;
-const key = document.querySelector('input#key').value;
+var iv = document.querySelector('input#iv').value;
+var key = document.querySelector('input#key').value;
 const mimeType = document.querySelector('input#mime_type').value;
 const fileName = document.querySelector('input#file_name').value;
 
@@ -87,6 +87,12 @@ const handleFile = async bytes => {
     currentProgress = 80;
 
     if (file === null) {
+        if (iv === "" || key === "") {
+            const fragments = window.location.hash.substring(1).split('~');
+            iv = fragments[0];
+            key = fragments[1];
+        }
+
         file = await decryptFile(
             bytes,
             key,

--- a/frontend/file.js
+++ b/frontend/file.js
@@ -52,7 +52,7 @@ button.addEventListener('click', () => {
 
     xhr.onload = () => {
         if (xhr.status === 200) {
-            handleFile(xhr.response);
+            handleFile(xhr.response).catch(() => error("Failed decrypting file."));
         } else {
             const data = JSON.parse(xhr.responseText);
             error(data.message);

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -67,7 +67,7 @@ class FileUpload {
             const body = JSON.parse(xhr.responseText);
 
             if (body.success) {
-                this.success(`${window.location.protocol}//${window.location.hostname}/file/${body.uuid}?v=${file.iv}&k=${file.key}`);
+                this.success(`${window.location.protocol}//${window.location.hostname}/file/${body.uuid}#${file.iv}~${file.key}`);
             } else {
                 this.error(body.message);
             }


### PR DESCRIPTION
Closes #2 

- The search query `key` and `iv` are optional now
- If it's not set the client will look for the key and iv in the url hash which stays on the client side
- Show error message when decryption fails